### PR TITLE
Bitfinex aggregate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - run:
           name: Build library
           command: stack build
+          no_output_timeout: 30m
       - run:
           name: Build tests
           command: stack test --no-run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: stack setup
       - run:
           name: Build library
-          command: stack build
+          command: stack build -j1
           no_output_timeout: 30m
       - run:
           name: Build tests

--- a/src/CryptoVenues/Fetch/DataSrc.hs
+++ b/src/CryptoVenues/Fetch/DataSrc.hs
@@ -9,7 +9,7 @@ import qualified Network.HTTP.Client   as HTTP
 data DataSrc dataType = DataSrc
    { dsUrl     :: BaseUrl
    , dsClientM :: SC.ClientM dataType
-   }
+   } deriving Functor
 
 srcFetch
    :: forall m dataType.

--- a/src/CryptoVenues/Venues.hs
+++ b/src/CryptoVenues/Venues.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module CryptoVenues.Venues
 ( allVenues
 , allVenuesText
@@ -11,12 +12,17 @@ import CryptoVenues.Fetch.MarketBook
 
 import CryptoVenues.Venues.Coinbase     as Coinbase       ()
 import CryptoVenues.Venues.Bitstamp     as Bitstamp       ()
-import CryptoVenues.Venues.Bitfinex     as Bitfinex       ()
+import qualified CryptoVenues.Venues.Bitfinex     as Bitfinex
 import CryptoVenues.Venues.Bittrex      as Bittrex        ()
 import CryptoVenues.Venues.Binance      as Binance        ()
 
 import qualified Data.HashMap.Strict   as HM
 
+
+-- | Choose "aggregated mode". See: "CryptoVenues.Venues.Bitfinex".
+instance MarketBook "bitfinex" where
+   marketBook = Bitfinex.marketBook_Agg
+   rateLimit = Bitfinex.marketBook_rateLimit
 
 -- | Canonical list of all supported venues ('AnyVenue')
 allVenues :: [AnyVenue]
@@ -41,3 +47,4 @@ venueLookup :: Text -> Maybe AnyVenue
 venueLookup = (`HM.lookup` venueMap)
 
 
+   

--- a/test/Spec/Orphans.hs
+++ b/test/Spec/Orphans.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Spec.Orphans
+(
+)
+where
+
+import           CryptoVenues.Internal.CPrelude
+import           CryptoVenues.Fetch.MarketBook
+import           CryptoVenues.Fetch.EnumMarkets
+import           CryptoVenues.Types.Market        (MarketList)
+import qualified CryptoVenues.Venues.Bitfinex     as Bitfinex
+import           Unsafe.Coerce                    (unsafeCoerce)
+
+
+instance EnumMarkets "bitfinex-raw" where
+   allMarkets = unsafeCoerce (allMarkets :: DataSrc (MarketList "bitfinex"))
+
+instance MarketBook "bitfinex-raw" where
+   marketBook = unsafeCoerce . Bitfinex.marketBook_Raw
+   rateLimit = unsafeCoerce Bitfinex.marketBook_rateLimit

--- a/test/Spec/VenueFetch.hs
+++ b/test/Spec/VenueFetch.hs
@@ -4,6 +4,7 @@ where
 
 import CryptoVenues.Internal.CPrelude
 import qualified CryptoVenues.Venues as Venues
+import           Spec.Orphans ()
 import qualified Spec.RateLimit as RateLimit
 import CryptoVenues.Fetch
 
@@ -18,7 +19,9 @@ minNumMarkets = 5
 
 spec :: HTTP.Manager -> Word -> Spec
 spec man maxRetries = parallel $
-   forM_ Venues.allVenues (testVenue man maxRetries)
+   forM_ allVenuesBitfinexRaw (testVenue man maxRetries)
+  where
+   allVenuesBitfinexRaw = AnyVenue (Proxy :: Proxy "bitfinex-raw") : Venues.allVenues
 
 testVenue :: HTTP.Manager -> Word -> AnyVenue -> Spec
 testVenue man maxRetries av@(AnyVenue (_ :: Proxy venue)) =


### PR DESCRIPTION
* Bitfinex: default to “aggregation mode”
* Minor CircleCI fixes

# Bitfinex details:

The Bitfinex order book API has two modes, and it's necessary to choose one.

 *Raw* mode returns raw orders from the order book, so that it's possible to distinguish between
 multiple orders of the same price and quantity. This mode has 100% price precision,
 but only returns a small part of the order book (since Bitfinex doesn't
 allow fetching more than 100 orders from an order book).

 *Aggregation* mode aggregates multiple almost-same-priced orders into a single order.
 This mode thus loses price precision but enables fetching a larger part of the order book.

 **Raw mode:**

 * Advantage: 100% price precision.
 * Disadvantage: only tiny part of order book for large order books (e.g. ~0.01% price range for ETH/BTC)

 **Aggregation mode:**

 * Advantage: larger part of order book, even for large order books (e.g. ~5% price range for ETH/BTC)
 * Disadvantage: less than 100% precision (seemingly 99.9% precision)