### PR TITLE
Rename Bitfinex internal symbols to official ones

### DIFF
--- a/crypto-venues.cabal
+++ b/crypto-venues.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5f2e9b5d0606b2f84b933ed10898924a7955b6aca899bf0b4887298d5c41e76b
+-- hash: 214650d4380c4d610f25cb7c45ed75b659724736b01b54fd90342410583a19b3
 
 name:           crypto-venues
 version:        0.3.0.0
@@ -47,6 +47,7 @@ library
       CryptoVenues.Venues
       CryptoVenues.Venues.Binance
       CryptoVenues.Venues.Bitfinex
+      CryptoVenues.Venues.Bitfinex.Mapping
       CryptoVenues.Venues.Bitstamp
       CryptoVenues.Venues.Bittrex
       CryptoVenues.Venues.Coinbase
@@ -67,6 +68,7 @@ library
     , containers
     , deepseq
     , errors
+    , exceptions
     , fgl
     , formatting
     , hashable

--- a/package.yaml
+++ b/package.yaml
@@ -80,6 +80,7 @@ library:
   - logging
   - formatting
   - utf8-string   # CryptoVenues.Venues.Bitstamp
+  - exceptions
 
 tests:
   crypto-venues-test:

--- a/src/CryptoVenues/Internal/Prelude.hs
+++ b/src/CryptoVenues/Internal/Prelude.hs
@@ -13,6 +13,7 @@ module CryptoVenues.Internal.Prelude
 , fail
 , S.BaseUrl(..), S.Scheme(..)
 , show'
+, groupOnOrd
 )
 where
 
@@ -38,3 +39,13 @@ sameSym a b = isJust (sameSymbol a b)
 
 instance MonadFail (Either Text) where
   fail = Left . toS
+
+-- | @groupOnOrd f lst@ first sorts the list by @f@ and then groups by @f@.
+--
+-- Example:
+--
+-- >>> groupOnOrd fst [("a", 1), ("b", 2), ("a", 3)]
+-- [[("a",1),("a",3)],[("b",2)]]
+groupOnOrd :: Ord o => (t -> o) -> [t] -> [[t]]
+groupOnOrd f =
+  groupBy (\m1 m2 -> f m1 == f m2) . sortOn f

--- a/src/CryptoVenues/Venues/Bitfinex/Mapping.hs
+++ b/src/CryptoVenues/Venues/Bitfinex/Mapping.hs
@@ -1,0 +1,131 @@
+{-|
+Module      : CryptoVenues.Venues.Bitfinex.ResponseMapping
+Description : Mappings from Bitfinex internal symbols to official symbols
+
+Bitfinex uses its own three-letter symbols for cryptocurrencies. This module
+uses Bitfinex' API to return a mapping of Bitfinex' internal symbols to the
+symbols used by everyone else.
+
+-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module CryptoVenues.Venues.Bitfinex.Mapping
+( ApiMapping
+, Response
+, Mapping
+, responseMapping
+, normalize
+, BitfinexOverlappingMarkets
+)
+where
+
+import Prelude
+import CryptoVenues.Internal.CPrelude (Generic, fromMaybe, Exception, groupOnOrd, NFData)
+import CryptoVenues.Types.Market (Market(..), MarketList(MarketList), getMarkets)
+
+import           Servant.API (JSON, type (:>), Get)
+import           Data.Vector (Vector)
+import qualified Data.Aeson as Json
+import qualified Data.Vector as Vec
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import           Unsafe.Coerce (unsafeCoerce)
+import qualified Control.Monad.Catch as Catch
+import Data.List (unlines)
+
+
+-- | Docs: https://docs.bitfinex.com/reference#rest-public-conf
+--   URL: https://api-pub.bitfinex.com/v2/conf/pub:map:currency:sym
+type ApiMapping
+   = "v2"
+   :> "conf"
+   :> "pub:map:currency:sym"
+   :> Get '[JSON] Response
+
+-- An outer array of length one which contains an array of tuples (two-element arrays in JSON)
+newtype Response = Response (Vector (Vector ResponseMapping))
+    deriving (Generic)
+
+-- | A map from Bitfinex' internal symbol to the symbol used by everyone else
+responseMapping :: Response -> Mapping
+responseMapping =
+    Mapping . toMap
+            . ignorePerpetualFutures
+            . map getResponseMapping
+            . Vec.toList
+            . Vec.head
+            . getResponse
+  where
+    toMap = Map.fromList
+    getResponse (Response vec) = vec
+    -- convert the "to" component (second element in the tuple) to upper case
+    getResponseMapping (ResponseMapping mapping) = fmap T.toUpper mapping
+    -- Symbols ending in "F0" are perpetual futures contracts, and the API says that
+    --  e.g. "BTCF0" is equivalent to "BTC", but we do not consider a perpetual
+    --  futures contract to be equal to its underlying asset.
+    ignorePerpetualFutures = filter (not . isPerpetualFuture . fst)
+    isPerpetualFuture symbol = "F0" `T.isSuffixOf` symbol
+
+instance Json.FromJSON ResponseMapping
+instance Json.FromJSON Response
+
+-- | The API returns a mapping as a tuple (two-element JSON array)
+--    where the first element is "from" and the second is "to".
+newtype ResponseMapping = ResponseMapping (T.Text, T.Text) -- ^ (from, to)
+    deriving (Generic)
+
+newtype Mapping = Mapping (Map.Map T.Text T.Text)
+    deriving (Eq, Show, Ord, NFData)
+
+-- | Convert an internal Bitfinex symbol into an official symbol
+normalizeMarket
+    :: Mapping
+    -> Market "bitfinex_internal" -- ^ Contains a Bitfinex internal symbol (e.g. "UST")
+    -> Market "bitfinex" -- ^ Contains an official symbol (e.g. "USDT")
+normalizeMarket (Mapping mapping) market = unsafeCoerce $
+    market
+        { miBase = normalizeSymbol (miBase market)
+        , miQuote = normalizeSymbol (miQuote market)
+        }
+  where
+    normalizeSymbol symbol =
+        fromMaybe symbol (Map.lookup symbol mapping)
+
+-- | Convert internal Bitfinex symbols into official symbols
+normalize
+    :: Catch.MonadThrow m
+    => Mapping
+    -> MarketList "bitfinex_internal"  -- ^ Contains Bitfinex internal symbols (e.g. "UST")
+    -> m (MarketList "bitfinex")  -- ^ Contains official symbols (e.g. "USDT")
+normalize mapping markets =
+    if not (null overlappingMarkets)
+        then Catch.throwM $ BitfinexOverlappingMarkets overlappingMarkets mapping
+        else pure $ MarketList newMarketList
+  where
+    newMarketList = map (normalizeMarket mapping) (getMarkets markets)
+    overlappingMarkets = getOverlappingMarkets newMarketList
+    getOverlappingMarkets =
+        filter ((> 1) . length) . groupOnOrd (\mkt -> (miBase mkt, miQuote mkt))
+
+-- | Exception thrown in case the process of renaming internal Bitfinex
+--    symbols into official symbols results in two different markets
+--    with the same "base" and "quote" symbol.
+--   This is considered a bug in the Bitfinex API and is thefore fatal.
+data BitfinexOverlappingMarkets = BitfinexOverlappingMarkets [[Market "bitfinex"]] Mapping
+
+instance Show BitfinexOverlappingMarkets where
+   show (BitfinexOverlappingMarkets overlappingMarkets mapping) =
+      let githubUrl =
+              "https://github.com/runeksvendsen/crypto-venues/issues/new?title=Bug:+overlapping+Bitfinex+markets"
+          details = unlines
+              [ "Markets: " <> show overlappingMarkets
+              , "Mapping: " <> show mapping
+              ]
+      in unlines
+      [ "BUG: Bitfinex market overlap"
+      , "Please report this issue at the following GitHub URL, and add the below info to the issue."
+      , "GitHub issue URL: " <> githubUrl
+      , "DETAILS:"
+      , details
+      ]
+
+instance Exception BitfinexOverlappingMarkets


### PR DESCRIPTION
Bitfinex uses its own set of symbols that no one else uses. E.g. it uses UST instead of USDT, UDC instead of USDC, and IOT instead of IOTA.

Luckily, Bitfinex has an API which seems to sort of translate from internal symbols into official ones. However, this API also translates e.g. BTCF0 to BTC, where BTCF0 is a "perpetual futures contract" for BTC, ie. not equivalent to BTC. Therefore, this API is used to translate Bitfinex internal symbols to official ones, but ignoring symbols that end with "F0".